### PR TITLE
refactor(sketch): sketch 컴포넌트 재사용한 기능별로 분리

### DIFF
--- a/src/components/DrawerSlider.tsx
+++ b/src/components/DrawerSlider.tsx
@@ -1,0 +1,117 @@
+import Slider from '@react-native-community/slider'
+import { useState } from 'react'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+interface Props {
+  min: number
+  max: number
+  value: number
+  onChangeValue: (value: number) => void
+  step: number
+}
+
+export default function DrawerSlider({
+  min,
+  max,
+  value,
+  onChangeValue,
+  step
+}: Props) {
+  // 드로어 열림/닫힘 상태
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  function onChangeValueCallback(value: number) {
+    onChangeValue(value)
+  }
+  return (
+    <View style={styles.drawerContainer}>
+      <Pressable
+        style={styles.dragHandle}
+        onPress={() => setIsDrawerOpen(!isDrawerOpen)}>
+        <View style={styles.arrowIcon}>
+          <Text style={styles.arrowText}>{isDrawerOpen ? '▼' : '▲'}</Text>
+        </View>
+      </Pressable>
+
+      {isDrawerOpen && (
+        <View style={styles.drawerContent}>
+          <Text style={styles.strokeWidthLabel}>펜 두께: {value}px</Text>
+          <Slider
+            style={styles.slider}
+            minimumValue={1}
+            maximumValue={20}
+            value={value}
+            onValueChange={(value: number) => onChangeValueCallback(value)}
+            step={1}
+            minimumTrackTintColor="#111"
+            maximumTrackTintColor="#e6e6e6"
+          />
+        </View>
+      )}
+    </View>
+  )
+}
+const styles = StyleSheet.create({
+  // 드로어 컨테이너
+  drawerContainer: {
+    paddingBottom: 20,
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: -5 },
+    elevation: 8
+  },
+
+  // 드래그 핸들 (화살표)
+  dragHandle: {
+    alignItems: 'center',
+    paddingVertical: 12,
+    backgroundColor: '#f8f8f8',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20
+  },
+
+  // 화살표 아이콘
+  arrowIcon: {
+    width: 40,
+    height: 6,
+    backgroundColor: '#ccc',
+    borderRadius: 3,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+
+  // 화살표 텍스트
+  arrowText: {
+    fontSize: 12,
+    color: '#666',
+    fontWeight: 'bold'
+  },
+
+  // 드로어 내용
+  drawerContent: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    paddingBottom: 20
+  },
+
+  // 펜 두께 라벨
+  strokeWidthLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 16,
+    textAlign: 'center'
+  },
+
+  // 슬라이더
+  slider: {
+    width: '100%',
+    height: 40
+  }
+})

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -3,7 +3,8 @@ import {
   useRef,
   useState,
   forwardRef,
-  useImperativeHandle
+  useImperativeHandle,
+  memo
 } from 'react'
 import {
   View,
@@ -28,148 +29,153 @@ export interface DrawingCanvasRef {
   clear: () => void
 }
 
-const DrawingCanvas = forwardRef<DrawingCanvasRef, Props>(
-  ({ strokeColor, strokeWidth, backgroundColor }, ref) => {
-    const viewShotRef = useRef<ViewShot>(null)
+const DrawingCanvas = memo(
+  // 부모의 상태중 이 컴포넌트와 관계없는 상태가 변경되면 재 렌더링
+  forwardRef<DrawingCanvasRef, Props>(
+    ({ strokeColor, strokeWidth, backgroundColor }, ref) => {
+      const viewShotRef = useRef<ViewShot>(null)
 
-    useImperativeHandle(ref, () => ({
-      capture: async () => {
-        if (!viewShotRef.current) {
-          throw new Error('ViewShot ref is not available')
-        }
-        if (!('capture' in viewShotRef.current)) {
-          throw new Error('ViewShot capture method is not available')
-        }
-        return await viewShotRef.current.capture?.()
-      },
-      clear: () => {
-        setStrokes([])
-        setCurrent(null)
-      }
-    }))
-    const _safePointFromEvent = (e: GestureResponderEvent): Point | null => {
-      const ne: any = e?.nativeEvent
-      if (!ne) return null
-      const t = (ne.touches && ne.touches[0]) || ne
-      let x: number | undefined = t.locationX
-      let y: number | undefined = t.locationY
-      if (typeof x !== 'number' || typeof y !== 'number') {
-        if (typeof t.pageX === 'number' && typeof t.pageY === 'number') {
-          x = t.pageX
-          y = t.pageY
-        }
-      }
-      if (typeof x !== 'number' || typeof y !== 'number') return null
-      return { x, y }
-    }
+      console.log('DrawingCanvas rendered')
 
-    const pan: PanResponderInstance = useMemo(() => {
-      return PanResponder.create({
-        onStartShouldSetPanResponder: () => true,
-        onMoveShouldSetPanResponder: () => true,
-
-        onPanResponderGrant: e => {
-          const p = _safePointFromEvent(e)
-          if (!p) return
-          const s: Stroke = {
-            id: String(Date.now()),
-            color: strokeColor,
-            width: strokeWidth,
-            points: [p]
+      useImperativeHandle(ref, () => ({
+        capture: async () => {
+          if (!viewShotRef.current) {
+            throw new Error('ViewShot ref is not available')
           }
-          setCurrent(s)
+          if (!('capture' in viewShotRef.current)) {
+            throw new Error('ViewShot capture method is not available')
+          }
+          return await viewShotRef.current.capture?.()
         },
-
-        onPanResponderMove: (
-          e: GestureResponderEvent,
-          _gs: PanResponderGestureState
-        ) => {
-          const p = _safePointFromEvent(e)
-          setCurrent(prev => {
-            if (!prev || !p) return prev
-            const last = prev.points[prev.points.length - 1]
-            const dx = p.x - last.x
-            const dy = p.y - last.y
-            if (dx * dx + dy * dy < 1.5 * 1.5) return prev
-            return { ...prev, points: [...prev.points, p] }
-          })
-        },
-
-        onPanResponderRelease: () => {
-          setCurrent(s => {
-            if (s) setStrokes(arr => [...arr, s])
-            return null
-          })
-        },
-        onPanResponderTerminate: () => {
-          setCurrent(s => {
-            if (s) setStrokes(arr => [...arr, s])
-            return null
-          })
+        clear: () => {
+          setStrokes([])
+          setCurrent(null)
         }
-      })
-    }, [strokeColor, strokeWidth])
+      }))
+      const _safePointFromEvent = (e: GestureResponderEvent): Point | null => {
+        const ne: any = e?.nativeEvent
+        if (!ne) return null
+        const t = (ne.touches && ne.touches[0]) || ne
+        let x: number | undefined = t.locationX
+        let y: number | undefined = t.locationY
+        if (typeof x !== 'number' || typeof y !== 'number') {
+          if (typeof t.pageX === 'number' && typeof t.pageY === 'number') {
+            x = t.pageX
+            y = t.pageY
+          }
+        }
+        if (typeof x !== 'number' || typeof y !== 'number') return null
+        return { x, y }
+      }
 
-    const _toPath = (pts: Point[]) => {
-      if (pts.length === 0) return ''
-      const [start, ...rest] = pts
-      const move = `M ${start.x} ${start.y}`
-      const lines = rest.map(p => `L ${p.x} ${p.y}`).join(' ')
-      return `${move} ${lines}`
-    }
-    const [strokes, setStrokes] = useState<Stroke[]>([])
-    const [current, setCurrent] = useState<Stroke | null>(null)
-    return (
-      <View style={styles.cardOuter}>
-        {/* 내부는 라운드에 맞춰 컨텐츠를 자르기 위해 overflow: hidden */}
-        <View style={styles.cardInner}>
-          <ViewShot
-            ref={viewShotRef}
-            style={styles.shot}>
-            <View
-              style={styles.canvas}
-              {...pan.panHandlers}>
-              <Svg style={StyleSheet.absoluteFill}>
-                {/* 배경 */}
-                <Rect
-                  x={0}
-                  y={0}
-                  width="100%"
-                  height="100%"
-                  fill={backgroundColor}
-                />
+      const pan: PanResponderInstance = useMemo(() => {
+        return PanResponder.create({
+          onStartShouldSetPanResponder: () => true,
+          onMoveShouldSetPanResponder: () => true,
 
-                {/* 완료된 스트로크 */}
-                {strokes.map(s => (
-                  <Path
-                    key={s.id}
-                    d={_toPath(s.points)}
-                    stroke={s.color}
-                    strokeWidth={s.width}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
+          onPanResponderGrant: e => {
+            const p = _safePointFromEvent(e)
+            if (!p) return
+            const s: Stroke = {
+              id: String(Date.now()),
+              color: strokeColor,
+              width: strokeWidth,
+              points: [p]
+            }
+            setCurrent(s)
+          },
+
+          onPanResponderMove: (
+            e: GestureResponderEvent,
+            _gs: PanResponderGestureState
+          ) => {
+            const p = _safePointFromEvent(e)
+            setCurrent(prev => {
+              if (!prev || !p) return prev
+              const last = prev.points[prev.points.length - 1]
+              const dx = p.x - last.x
+              const dy = p.y - last.y
+              if (dx * dx + dy * dy < 1.5 * 1.5) return prev
+              return { ...prev, points: [...prev.points, p] }
+            })
+          },
+
+          onPanResponderRelease: () => {
+            setCurrent(s => {
+              if (s) setStrokes(arr => [...arr, s])
+              return null
+            })
+          },
+          onPanResponderTerminate: () => {
+            setCurrent(s => {
+              if (s) setStrokes(arr => [...arr, s])
+              return null
+            })
+          }
+        })
+      }, [strokeColor, strokeWidth])
+
+      const _toPath = (pts: Point[]) => {
+        if (pts.length === 0) return ''
+        const [start, ...rest] = pts
+        const move = `M ${start.x} ${start.y}`
+        const lines = rest.map(p => `L ${p.x} ${p.y}`).join(' ')
+        return `${move} ${lines}`
+      }
+      const [strokes, setStrokes] = useState<Stroke[]>([])
+      const [current, setCurrent] = useState<Stroke | null>(null)
+      return (
+        <View style={styles.cardOuter}>
+          {/* 내부는 라운드에 맞춰 컨텐츠를 자르기 위해 overflow: hidden */}
+          <View style={styles.cardInner}>
+            <ViewShot
+              ref={viewShotRef}
+              style={styles.shot}>
+              <View
+                style={styles.canvas}
+                {...pan.panHandlers}>
+                <Svg style={StyleSheet.absoluteFill}>
+                  {/* 배경 */}
+                  <Rect
+                    x={0}
+                    y={0}
+                    width="100%"
+                    height="100%"
+                    fill={backgroundColor}
                   />
-                ))}
 
-                {/* 현재 스트로크 */}
-                {current && (
-                  <Path
-                    d={_toPath(current.points)}
-                    stroke={current.color}
-                    strokeWidth={current.width}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                  />
-                )}
-              </Svg>
-            </View>
-          </ViewShot>
+                  {/* 완료된 스트로크 */}
+                  {strokes.map(s => (
+                    <Path
+                      key={s.id}
+                      d={_toPath(s.points)}
+                      stroke={s.color}
+                      strokeWidth={s.width}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill="none"
+                    />
+                  ))}
+
+                  {/* 현재 스트로크 */}
+                  {current && (
+                    <Path
+                      d={_toPath(current.points)}
+                      stroke={current.color}
+                      strokeWidth={current.width}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill="none"
+                    />
+                  )}
+                </Svg>
+              </View>
+            </ViewShot>
+          </View>
         </View>
-      </View>
-    )
-  }
+      )
+    }
+  )
 )
 
 DrawingCanvas.displayName = 'DrawingCanvas'

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -1,0 +1,210 @@
+import {
+  useMemo,
+  useRef,
+  useState,
+  forwardRef,
+  useImperativeHandle
+} from 'react'
+import {
+  View,
+  StyleSheet,
+  GestureResponderEvent,
+  PanResponder,
+  PanResponderGestureState,
+  PanResponderInstance
+} from 'react-native'
+import Svg, { Path, Rect } from 'react-native-svg'
+import ViewShot from 'react-native-view-shot'
+import { Point, Stroke } from '../types/sketch'
+
+interface Props {
+  strokeColor: string
+  strokeWidth: number
+  backgroundColor: string
+}
+
+export interface DrawingCanvasRef {
+  capture: () => Promise<string | undefined>
+  clear: () => void
+}
+
+const DrawingCanvas = forwardRef<DrawingCanvasRef, Props>(
+  ({ strokeColor, strokeWidth, backgroundColor }, ref) => {
+    const viewShotRef = useRef<ViewShot>(null)
+
+    useImperativeHandle(ref, () => ({
+      capture: async () => {
+        if (!viewShotRef.current) {
+          throw new Error('ViewShot ref is not available')
+        }
+        if (!('capture' in viewShotRef.current)) {
+          throw new Error('ViewShot capture method is not available')
+        }
+        return await viewShotRef.current.capture?.()
+      },
+      clear: () => {
+        setStrokes([])
+        setCurrent(null)
+      }
+    }))
+    const _safePointFromEvent = (e: GestureResponderEvent): Point | null => {
+      const ne: any = e?.nativeEvent
+      if (!ne) return null
+      const t = (ne.touches && ne.touches[0]) || ne
+      let x: number | undefined = t.locationX
+      let y: number | undefined = t.locationY
+      if (typeof x !== 'number' || typeof y !== 'number') {
+        if (typeof t.pageX === 'number' && typeof t.pageY === 'number') {
+          x = t.pageX
+          y = t.pageY
+        }
+      }
+      if (typeof x !== 'number' || typeof y !== 'number') return null
+      return { x, y }
+    }
+
+    const pan: PanResponderInstance = useMemo(() => {
+      return PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+
+        onPanResponderGrant: e => {
+          const p = _safePointFromEvent(e)
+          if (!p) return
+          const s: Stroke = {
+            id: String(Date.now()),
+            color: strokeColor,
+            width: strokeWidth,
+            points: [p]
+          }
+          setCurrent(s)
+        },
+
+        onPanResponderMove: (
+          e: GestureResponderEvent,
+          _gs: PanResponderGestureState
+        ) => {
+          const p = _safePointFromEvent(e)
+          setCurrent(prev => {
+            if (!prev || !p) return prev
+            const last = prev.points[prev.points.length - 1]
+            const dx = p.x - last.x
+            const dy = p.y - last.y
+            if (dx * dx + dy * dy < 1.5 * 1.5) return prev
+            return { ...prev, points: [...prev.points, p] }
+          })
+        },
+
+        onPanResponderRelease: () => {
+          setCurrent(s => {
+            if (s) setStrokes(arr => [...arr, s])
+            return null
+          })
+        },
+        onPanResponderTerminate: () => {
+          setCurrent(s => {
+            if (s) setStrokes(arr => [...arr, s])
+            return null
+          })
+        }
+      })
+    }, [strokeColor, strokeWidth])
+
+    const _toPath = (pts: Point[]) => {
+      if (pts.length === 0) return ''
+      const [start, ...rest] = pts
+      const move = `M ${start.x} ${start.y}`
+      const lines = rest.map(p => `L ${p.x} ${p.y}`).join(' ')
+      return `${move} ${lines}`
+    }
+    const [strokes, setStrokes] = useState<Stroke[]>([])
+    const [current, setCurrent] = useState<Stroke | null>(null)
+    return (
+      <View style={styles.cardOuter}>
+        {/* 내부는 라운드에 맞춰 컨텐츠를 자르기 위해 overflow: hidden */}
+        <View style={styles.cardInner}>
+          <ViewShot
+            ref={viewShotRef}
+            style={styles.shot}>
+            <View
+              style={styles.canvas}
+              {...pan.panHandlers}>
+              <Svg style={StyleSheet.absoluteFill}>
+                {/* 배경 */}
+                <Rect
+                  x={0}
+                  y={0}
+                  width="100%"
+                  height="100%"
+                  fill={backgroundColor}
+                />
+
+                {/* 완료된 스트로크 */}
+                {strokes.map(s => (
+                  <Path
+                    key={s.id}
+                    d={_toPath(s.points)}
+                    stroke={s.color}
+                    strokeWidth={s.width}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    fill="none"
+                  />
+                ))}
+
+                {/* 현재 스트로크 */}
+                {current && (
+                  <Path
+                    d={_toPath(current.points)}
+                    stroke={current.color}
+                    strokeWidth={current.width}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    fill="none"
+                  />
+                )}
+              </Svg>
+            </View>
+          </ViewShot>
+        </View>
+      </View>
+    )
+  }
+)
+
+DrawingCanvas.displayName = 'DrawingCanvas'
+
+export default DrawingCanvas
+
+const RADIUS = 16
+const styles = StyleSheet.create({
+  // 카드 바깥: 그림자/모서리/테두리
+  cardOuter: {
+    borderRadius: RADIUS,
+    backgroundColor: '#fff',
+    // iOS shadow
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    // Android shadow
+    elevation: 4,
+    // 살짝의 테두리로 카드 느낌 강화
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#e6e6e6'
+  },
+  // 카드 안쪽: 라운드에 맞춰 컨텐츠를 자르기
+  cardInner: {
+    borderRadius: RADIUS,
+    overflow: 'hidden'
+  },
+  shot: {
+    // 캔버스 높이 (필요 시 외부 style로 덮어쓰기 가능)
+    height: 320
+  },
+  canvas: {
+    flex: 1
+    // 연한 배경무늬를 주고 싶다면 여기서도 조절 가능
+    // backgroundColor는 SVG의 Rect로 칠하고 있으므로 투명 유지
+  }
+})

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,0 +1,48 @@
+import { View, Text, StyleSheet, Image } from 'react-native'
+interface Props {
+  src: string
+  title: string
+}
+export default function ImageCard({ src, title }: Props) {
+  return (
+    <View style={styles.ImageContainer}>
+      <Text style={styles.ImageTitle}>{title}</Text>
+      <View style={styles.ImageCard}>
+        <Image
+          source={{ uri: src }}
+          style={styles.Image}
+          resizeMode="contain"
+        />
+      </View>
+    </View>
+  )
+}
+const styles = StyleSheet.create({
+  ImageContainer: {
+    marginTop: 16,
+    paddingHorizontal: 4
+  },
+  ImageTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 8
+  },
+  ImageCard: {
+    borderRadius: 16,
+    backgroundColor: '#fff',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#e6e6e6',
+    overflow: 'hidden'
+  },
+  Image: {
+    width: '100%',
+    height: 200,
+    backgroundColor: '#f8f8f8'
+  }
+})

--- a/src/components/MemoSketch.tsx
+++ b/src/components/MemoSketch.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react'
-import {
-  View,
-  StyleSheet,
-  Pressable,
-  Text,
-  ViewStyle,
-  Alert,
-  TextInput
-} from 'react-native'
+import { View, StyleSheet, ViewStyle, Alert, TextInput } from 'react-native'
 import * as FileSystem from 'expo-file-system/legacy'
 import * as MediaLibrary from 'expo-media-library'
 import { SketchUploader } from '../managers/SketchUploader'

--- a/src/components/MemoSketch.tsx
+++ b/src/components/MemoSketch.tsx
@@ -1,38 +1,26 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import {
   View,
   StyleSheet,
-  PanResponder,
-  PanResponderInstance,
-  GestureResponderEvent,
-  PanResponderGestureState,
   Pressable,
   Text,
   ViewStyle,
   Alert,
-  Image,
-  Modal,
   TextInput
 } from 'react-native'
-import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context'
-import Svg, { Path, Rect } from 'react-native-svg'
-import ViewShot from 'react-native-view-shot'
 import * as FileSystem from 'expo-file-system/legacy'
 import * as MediaLibrary from 'expo-media-library'
-import type { Stroke, Point } from '../types/sketch'
 import { SketchUploader } from '../managers/SketchUploader'
-import Title from './Title'
 import { GalleryPickerManager } from '../managers/GalleryPickerManager'
 import { PickedAsset } from '../managers/types'
 import ImageModal from './ImageModal'
-import Slider from '@react-native-community/slider'
+import ImageCard from './ImageCard'
+import DrawerSlider from './DrawerSlider'
+import DrawingCanvas, { DrawingCanvasRef } from './DrawingCanvas'
 
 type Props = {
   uploadUrl: string
   style?: ViewStyle
-  strokeColor?: string
-  strokeWidth?: number
-  backgroundColor?: string
   onUploaded?: (res: Response) => void
   onError?: (err: unknown) => void
 }
@@ -40,130 +28,32 @@ type Props = {
 export const MemoSketch: React.FC<Props> = ({
   uploadUrl,
   style,
-  strokeColor = '#111',
-  strokeWidth = 4,
-  backgroundColor = '#fff',
   onUploaded,
   onError
 }) => {
+  const defaultStrokeWidth = 4
   const [image, setImage] = useState<PickedAsset | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [modalVisible, setModalVisible] = useState(false)
-  const [strokes, setStrokes] = useState<Stroke[]>([])
-  const [current, setCurrent] = useState<Stroke | null>(null)
-  const [imageUrl, setImageUrl] = useState<string>('')
   const [serverImageBlob, setServerImageBlob] = useState<string | null>(null)
-  const viewShotRef = useRef<ViewShot>(null)
+  const drawingCanvasRef = useRef<DrawingCanvasRef>(null)
   const [text, onChangeText] = useState('')
 
   //drawing area
-  const [currentStrokeWidth, setCurrentStrokeWidth] = useState(strokeWidth)
-  // 드로어 열림/닫힘 상태
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  // 드래그 제스처를 위한 상태
-  const [drawerHeight, setDrawerHeight] = useState(0)
-
-  // 컴포넌트 렌더링 추적
-  // console.log('🔄 MemoSketch 컴포넌트 렌더링')
-  // console.log('📊 현재 strokes 개수:', strokes.length)
-  // console.log('📊 현재 current stroke:', current ? '있음' : '없음')
-
-  const _safePointFromEvent = (e: GestureResponderEvent): Point | null => {
-    const ne: any = e?.nativeEvent
-    if (!ne) return null
-    const t = (ne.touches && ne.touches[0]) || ne
-    let x: number | undefined = t.locationX
-    let y: number | undefined = t.locationY
-    if (typeof x !== 'number' || typeof y !== 'number') {
-      if (typeof t.pageX === 'number' && typeof t.pageY === 'number') {
-        x = t.pageX
-        y = t.pageY
-      }
-    }
-    if (typeof x !== 'number' || typeof y !== 'number') return null
-    return { x, y }
-  }
-
-  const pan: PanResponderInstance = useMemo(() => {
-    // console.log('🔧 PanResponder가 새로 생성되었습니다!')
-    // console.log('📊 strokeColor:', strokeColor)
-    // console.log('📊 strokeWidth:', strokeWidth)
-    // console.log('⏰ 생성 시간:', new Date().toLocaleTimeString())
-
-    return PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-
-      onPanResponderGrant: e => {
-        const p = _safePointFromEvent(e)
-        if (!p) return
-        const s: Stroke = {
-          id: String(Date.now()),
-          color: strokeColor,
-          width: currentStrokeWidth,
-          points: [p]
-        }
-        setCurrent(s)
-      },
-
-      onPanResponderMove: (
-        e: GestureResponderEvent,
-        _gs: PanResponderGestureState
-      ) => {
-        const p = _safePointFromEvent(e)
-        setCurrent(prev => {
-          if (!prev || !p) return prev
-          const last = prev.points[prev.points.length - 1]
-          const dx = p.x - last.x
-          const dy = p.y - last.y
-          if (dx * dx + dy * dy < 1.5 * 1.5) return prev
-          return { ...prev, points: [...prev.points, p] }
-        })
-      },
-
-      onPanResponderRelease: () => {
-        setCurrent(s => {
-          if (s) setStrokes(arr => [...arr, s])
-          return null
-        })
-      },
-      onPanResponderTerminate: () => {
-        setCurrent(s => {
-          if (s) setStrokes(arr => [...arr, s])
-          return null
-        })
-      }
-    })
-  }, [strokeColor, currentStrokeWidth])
-
-  const _toPath = (pts: Point[]) => {
-    if (pts.length === 0) return ''
-    const [start, ...rest] = pts
-    const move = `M ${start.x} ${start.y}`
-    const lines = rest.map(p => `L ${p.x} ${p.y}`).join(' ')
-    return `${move} ${lines}`
-  }
-
-  const handleClear = () => {
-    setStrokes([])
-    setCurrent(null)
-  }
+  const [currentStrokeWidth, setCurrentStrokeWidth] =
+    useState(defaultStrokeWidth)
 
   const handleSend = async () => {
     try {
-      if (!viewShotRef.current) {
-        throw new Error('ViewShot ref is not available')
-      }
-
-      if (!('capture' in viewShotRef.current)) {
-        throw new Error('ViewShot capture method is not available')
+      if (!drawingCanvasRef.current) {
+        throw new Error('DrawingCanvas ref is not available')
       }
 
       console.log('📸 스크린샷 캡처 시작...')
 
       // 파일 경로로 캡처 후 base64로 변환
-      const fileUri = await viewShotRef.current.capture?.()
+      const fileUri = await drawingCanvasRef.current.capture()
       console.log('📸 캡처된 파일 URI:', fileUri)
 
       if (!fileUri) {
@@ -207,18 +97,14 @@ export const MemoSketch: React.FC<Props> = ({
 
   const handleSaveToGallery = async () => {
     try {
-      if (!viewShotRef.current) {
-        throw new Error('ViewShot ref is not available')
-      }
-
-      if (!('capture' in viewShotRef.current)) {
-        throw new Error('ViewShot capture method is not available')
+      if (!drawingCanvasRef.current) {
+        throw new Error('DrawingCanvas ref is not available')
       }
 
       console.log('📸 갤러리 저장용 스크린샷 캡처 시작...')
 
       // 파일 경로로 캡처
-      const fileUri = await viewShotRef.current.capture?.()
+      const fileUri = await drawingCanvasRef.current.capture()
       console.log('📸 캡처된 파일 URI:', fileUri)
 
       if (!fileUri) {
@@ -280,61 +166,18 @@ export const MemoSketch: React.FC<Props> = ({
         />
       )}
 
-      {/* 카드형 래퍼 (그림자/라운드) */}
-      <View style={styles.cardOuter}>
-        {/* 내부는 라운드에 맞춰 컨텐츠를 자르기 위해 overflow: hidden */}
-        <View style={styles.cardInner}>
-          <ViewShot
-            ref={viewShotRef}
-            style={styles.shot}>
-            <View
-              style={styles.canvas}
-              {...pan.panHandlers}>
-              <Svg style={StyleSheet.absoluteFill}>
-                {/* 배경 */}
-                <Rect
-                  x={0}
-                  y={0}
-                  width="100%"
-                  height="100%"
-                  fill={backgroundColor}
-                />
-
-                {/* 완료된 스트로크 */}
-                {strokes.map(s => (
-                  <Path
-                    key={s.id}
-                    d={_toPath(s.points)}
-                    stroke={s.color}
-                    strokeWidth={s.width}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                  />
-                ))}
-
-                {/* 현재 스트로크 */}
-                {current && (
-                  <Path
-                    d={_toPath(current.points)}
-                    stroke={current.color}
-                    strokeWidth={current.width}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                  />
-                )}
-              </Svg>
-            </View>
-          </ViewShot>
-        </View>
-      </View>
+      <DrawingCanvas
+        ref={drawingCanvasRef}
+        strokeColor="#111"
+        strokeWidth={currentStrokeWidth}
+        backgroundColor="#fff"
+      />
 
       {/* 툴바 */}
       <View style={styles.toolbar}>
         <ToolButton
           label="Clear"
-          onPress={handleClear}
+          onPress={() => drawingCanvasRef.current?.clear()}
         />
         <ToolButton
           label="Send"
@@ -364,47 +207,20 @@ export const MemoSketch: React.FC<Props> = ({
         />
       </View>
 
-      {/* 서버로부터 받은 이미지 표시 영역 */}
-      {serverImageBlob && (
-        <View style={styles.serverImageContainer}>
-          <Text style={styles.serverImageTitle}>서버 응답 이미지</Text>
-          <View style={styles.serverImageCard}>
-            <Image
-              source={{ uri: serverImageBlob }}
-              style={styles.serverImage}
-              resizeMode="contain"
-            />
-          </View>
-        </View>
+      {!serverImageBlob && (
+        <ImageCard
+          src={serverImageBlob}
+          title="서버응답 이미지"
+        />
       )}
 
-      <View style={styles.drawerContainer}>
-        <Pressable
-          style={styles.dragHandle}
-          onPress={() => setIsDrawerOpen(!isDrawerOpen)}>
-          <View style={styles.arrowIcon}>
-            <Text style={styles.arrowText}>{isDrawerOpen ? '▼' : '▲'}</Text>
-          </View>
-        </Pressable>
-
-        {isDrawerOpen && (
-          <View style={styles.drawerContent}>
-            <Text style={styles.strokeWidthLabel}>
-              펜 두께: {currentStrokeWidth}px
-            </Text>
-            <Slider
-              style={styles.slider}
-              minimumValue={1}
-              maximumValue={20}
-              value={currentStrokeWidth}
-              onValueChange={setCurrentStrokeWidth}
-              step={1}
-              minimumTrackTintColor="#111"
-              maximumTrackTintColor="#e6e6e6"
-            />
-          </View>
-        )}
-      </View>
+      <DrawerSlider
+        min={1}
+        max={20}
+        value={currentStrokeWidth}
+        onChangeValue={setCurrentStrokeWidth}
+        step={1}
+      />
     </View>
   )
 }
@@ -423,42 +239,10 @@ const ToolButton = ({
   </Pressable>
 )
 
-const RADIUS = 16
-
 const styles = StyleSheet.create({
   container: {
     width: '100%',
     flex: 1
-    // 카드와 툴바 사이 간격
-  },
-  // 카드 바깥: 그림자/모서리/테두리
-  cardOuter: {
-    borderRadius: RADIUS,
-    backgroundColor: '#fff',
-    // iOS shadow
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 6 },
-    // Android shadow
-    elevation: 4,
-    // 살짝의 테두리로 카드 느낌 강화
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#e6e6e6'
-  },
-  // 카드 안쪽: 라운드에 맞춰 컨텐츠를 자르기
-  cardInner: {
-    borderRadius: RADIUS,
-    overflow: 'hidden'
-  },
-  shot: {
-    // 캔버스 높이 (필요 시 외부 style로 덮어쓰기 가능)
-    height: 320
-  },
-  canvas: {
-    flex: 1
-    // 연한 배경무늬를 주고 싶다면 여기서도 조절 가능
-    // backgroundColor는 SVG의 Rect로 칠하고 있으므로 투명 유지
   },
   toolbar: {
     marginTop: 12,
@@ -474,34 +258,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#111'
   },
   btnText: { color: '#fff', fontWeight: '600' },
-  // 서버 이미지 표시 영역 스타일
-  serverImageContainer: {
-    marginTop: 16,
-    paddingHorizontal: 4
-  },
-  serverImageTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 8
-  },
-  serverImageCard: {
-    borderRadius: RADIUS,
-    backgroundColor: '#fff',
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 4,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#e6e6e6',
-    overflow: 'hidden'
-  },
-  serverImage: {
-    width: '100%',
-    height: 200,
-    backgroundColor: '#f8f8f8'
-  },
   input: {
     height: 100,
     margin: 12,
@@ -509,81 +265,5 @@ const styles = StyleSheet.create({
     padding: 10,
     borderRadius: 10,
     borderColor: '#ccc'
-  },
-
-  // 펜 두꼐 컨테이너
-  strokeWidthContainer: {
-    marginTop: 12,
-    marginBottom: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 4,
-    backgroundColor: '#f8f8f8',
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: '#e6e6e6'
-  },
-  // 드로어 컨테이너
-  drawerContainer: {
-    paddingBottom: 20,
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    backgroundColor: '#fff',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowRadius: 10,
-    shadowOffset: { width: 0, height: -5 },
-    elevation: 8
-  },
-
-  // 드래그 핸들 (화살표)
-  dragHandle: {
-    alignItems: 'center',
-    paddingVertical: 12,
-    backgroundColor: '#f8f8f8',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20
-  },
-
-  // 화살표 아이콘
-  arrowIcon: {
-    width: 40,
-    height: 6,
-    backgroundColor: '#ccc',
-    borderRadius: 3,
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
-
-  // 화살표 텍스트
-  arrowText: {
-    fontSize: 12,
-    color: '#666',
-    fontWeight: 'bold'
-  },
-
-  // 드로어 내용
-  drawerContent: {
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    paddingBottom: 20
-  },
-
-  // 펜 두께 라벨
-  strokeWidthLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 16,
-    textAlign: 'center'
-  },
-
-  // 슬라이더
-  slider: {
-    width: '100%',
-    height: 40
   }
 })

--- a/src/components/MemoSketch.tsx
+++ b/src/components/MemoSketch.tsx
@@ -17,6 +17,7 @@ import ImageModal from './ImageModal'
 import ImageCard from './ImageCard'
 import DrawerSlider from './DrawerSlider'
 import DrawingCanvas, { DrawingCanvasRef } from './DrawingCanvas'
+import ToolButton from './ToolButton'
 
 type Props = {
   uploadUrl: string
@@ -225,20 +226,6 @@ export const MemoSketch: React.FC<Props> = ({
   )
 }
 
-const ToolButton = ({
-  label,
-  onPress
-}: {
-  label: string
-  onPress: () => void
-}) => (
-  <Pressable
-    onPress={onPress}
-    style={styles.btn}>
-    <Text style={styles.btnText}>{label}</Text>
-  </Pressable>
-)
-
 const styles = StyleSheet.create({
   container: {
     width: '100%',
@@ -251,13 +238,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 4,
     justifyContent: 'flex-end'
   },
-  btn: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 10,
-    backgroundColor: '#111'
-  },
-  btnText: { color: '#fff', fontWeight: '600' },
   input: {
     height: 100,
     margin: 12,

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -1,0 +1,27 @@
+import { Pressable, Text, StyleSheet } from 'react-native'
+
+export default function ToolButton({
+  label,
+  onPress
+}: {
+  label: string
+  onPress: () => void
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={styles.btn}>
+      <Text style={styles.btnText}>{label}</Text>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  btn: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 10,
+    backgroundColor: '#111'
+  },
+  btnText: { color: '#fff', fontWeight: '600' }
+})


### PR DESCRIPTION
## 이슈 개요

### 재사용 가능한 컴포넌트들의 분리
- slider(펜두께 조절 컴포넌트)
- Canvas 컴포넌트
- ImageCard 컴포넌트

### Drawing Canvas의 React.memo도입
- 부모의 상태중 이 컴포넌트와 관계없는 상태가 변경되면 재 렌더링 방지
- 해당 컴포넌트는 이미 자체적으로 재렌더링이 많은 컴포넌트이므로 memo도입으로 인한 성능 향상 기대

<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/e147512b-f0c5-410f-90ae-1820f38c68e1" />


## TODO
- [ ] 메인 컴포넌트에서 canvas 컴포넌트로 stroke 상태이동
- [x] 재구성된 컴포넌트 다이어그램 그릴 것(데이터 공유 흐름도, 컴포넌트 아키텍처 등)

<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/c78cd870-f7ec-4470-a53b-2302023b819b" />
