### PR TITLE
feat(recomend-view): add recommend view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ImagePickerView from './components/ImagePickerView'
 import GallerySelectView from './pages/GallerySelectView'
 import { MemoSketch } from './components/MemoSketch'
 import TodoList from './components/TodoList'
+import RecommendView from './components/RecommendView'
 
 export default function App() {
   return (
@@ -12,7 +13,8 @@ export default function App() {
         <Text style={styles.dummyText}>Hello world!</Text>
       </View> */}
       {/* <GallerySelectView></GallerySelectView> */}
-      <MemoSketch uploadUrl={'set your ip'}></MemoSketch>
+      {/* <MemoSketch uploadUrl={'set your ip'}></MemoSketch> */}
+      <RecommendView />
       {/* <TodoList></TodoList> */}
     </View>
   )

--- a/src/components/RecommendView.tsx
+++ b/src/components/RecommendView.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Image,
+  Pressable,
+  Linking
+} from 'react-native'
+import { RecommendResponse, Result } from '../types/recommend'
+import mockData from '../mock/recommend.json'
+
+interface RecommendViewProps {
+  data?: RecommendResponse | null
+}
+
+export default function RecommendView({ data }: RecommendViewProps) {
+  const [displayData, setDisplayData] = useState<RecommendResponse | null>(data)
+
+  useEffect(() => {
+    if (!data) {
+      setDisplayData(mockData as RecommendResponse)
+    }
+  }, [data])
+
+  const handleLinkPress = async (link: string | null | undefined) => {
+    if (link) {
+      try {
+        const canOpen = await Linking.canOpenURL(link)
+        if (canOpen) {
+          await Linking.openURL(link)
+        }
+      } catch (error) {
+        console.error('링크 열기 실패:', error)
+      }
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>추천 결과</Text>
+      <ScrollView contentContainerStyle={styles.gridContainer}>
+        {displayData.results?.map((item: Result, index: number) => (
+          <View
+            key={index}
+            style={styles.card}>
+            {item.image && (
+              <Image
+                source={{ uri: item.image }}
+                style={styles.cardImage}
+                resizeMode="contain"
+              />
+            )}
+            <View style={styles.cardContent}>
+              {item.link && (
+                <Pressable onPress={() => handleLinkPress(item.link)}>
+                  <Text style={styles.linkText}>주소: 링크 열기</Text>
+                </Pressable>
+              )}
+              {item.price && (
+                <Text style={styles.priceText}>가격: {item.price}</Text>
+              )}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fff'
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#000',
+    marginBottom: 16
+  },
+  gridContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12
+  },
+  card: {
+    width: '31%',
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+    overflow: 'hidden',
+    marginBottom: 12
+  },
+  cardImage: {
+    width: '100%',
+    height: 150,
+    backgroundColor: '#f8f8f8'
+  },
+  cardContent: {
+    padding: 12
+  },
+  linkText: {
+    fontSize: 12,
+    color: '#0066cc',
+    marginBottom: 6,
+    textDecorationLine: 'underline'
+  },
+  priceText: {
+    fontSize: 12,
+    color: '#333'
+  }
+})

--- a/src/types/recommend.ts
+++ b/src/types/recommend.ts
@@ -1,0 +1,13 @@
+export interface RecommendResponse {
+  status: string // 필수 ("success")
+  prompt: string // 필수 (최종 검색 질의)
+  image_url: string // 필수 (업로드된 이미지 URL)
+  results?: Result[] | null // 선택 (빈 리스트 또는 None 가능)
+}
+
+export interface Result {
+  title?: string | null // 상품명
+  image?: string | null // 이미지 URL
+  link?: string | null // 상품 페이지 링크
+  price?: string | null // 가격 정보
+}


### PR DESCRIPTION
## 변경내용

### Recommend View 추가
- data없을때 mockData을 보여주도록 구성
```ts
const [displayData, setDisplayData] = useState<RecommendResponse | null>(data)

  useEffect(() => {
    if (!data) {
      setDisplayData(mockData as RecommendResponse)
    }
  }, [data])
```

### 변경 결과
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/c7378bb7-68e9-44af-bb2e-61b09133b085" />

### TODO
- [ ] 화면 이동 구현(라우팅)을 위한 컴포넌트 구조 변경 필요(react-navigation 학습 필요) 
     - [ ] react-navigation 학습 및 구현
     - [ ] 프로젝트에 적용
- [ ] 정합

    

